### PR TITLE
Make toolbar buttons look more like buttons

### DIFF
--- a/OpenDark/OpenDark.qss
+++ b/OpenDark/OpenDark.qss
@@ -9,11 +9,6 @@
   background-color: #212529;
   dialogbuttonbox-buttons-have-icons: 0; }
 
-/* specific reset for elements inside QToolBar */
-QToolBar * {
-  margin: 0px;
-  padding: 0px; }
-
 QAbstractSpinBox {
   max-height: 20px;
   margin: 0px;
@@ -477,9 +472,16 @@ QTextEdit {
 
 QToolBar {
   background-color: #212529;
-  margin-top: 6px;
-  padding: 0px;
+  padding: 2px;
   border-bottom: 1px solid #292f35; }
+  QToolBar * {
+    margin: 0;
+    padding: 0; }
+  QToolBar QTabBar::tab {
+    margin-top: -1px;
+    padding-top: 6px; }
+  QToolBar QPushButton, QToolBar QSint--ActionGroup QFrame[class="content"] QToolButton, QSint--ActionGroup QFrame[class="content"] QToolBar QToolButton, QToolBar QWidget#wbList QPushButton, QToolBar QWidget#wbList QSint--ActionGroup QFrame[class="content"] QToolButton, QSint--ActionGroup QFrame[class="content"] QToolBar QWidget#wbList QToolButton, QWidget#wbList QToolBar QPushButton, QWidget#wbList QToolBar QSint--ActionGroup QFrame[class="content"] QToolButton, QSint--ActionGroup QFrame[class="content"] QWidget#wbList QToolBar QToolButton {
+    padding: 3px; }
   QToolBar::separator {
     background-color: #495057; }
     QToolBar::separator:vertical {
@@ -495,34 +497,25 @@ QToolBarExtension {
   background-color: transparent;
   qproperty-icon: url(qss:images_dark-light/light_expand.svg); }
 
-QToolButton[popupMode="0"] {
-  /* Only for InstantPopup */
-  padding-right: -20px;
-  margin-right: -20px; }
-
-QToolButton[popupMode="1"] {
-  /* Only for InstantPopup */
-  padding-right: -20px;
-  margin-right: -20px; }
-
-QToolButton[popupMode="2"] {
+QToolButton[popupMode="0"], QToolButton[popupMode="1"], QToolButton[popupMode="2"] {
   /* Only for InstantPopup */
   padding-right: -20px;
   margin-right: -20px; }
 
 QToolButton {
-  margin: 0px 3px 0px 3px;
-  padding: 0px 0px 0px 0px;
+  margin: 0px 2px 0px 2px;
+  padding: 2px;
   border: 1px solid transparent;
-  border-radius: 2px; }
+  border-radius: 2px;
+  border-radius: 4px; }
   QToolButton:hover {
-    margin: 0px 3px 0px 3px;
-    border: 1px solid #264b69; }
+    margin: 0px 2px 0px 2px;
+    background: #495057; }
   QToolButton:focus {
-    margin: 0px 3px 0px 3px;
+    margin: 0px 2px 0px 2px;
     border: 1px solid #264b69; }
   QToolButton:pressed {
-    margin: 0px 3px 0px 3px;
+    margin: 0px 2px 0px 2px;
     border: 1px solid #264b69;
     background-color: #1f364d; }
   QToolButton:checked {
@@ -537,7 +530,7 @@ QToolButton {
     subcontrol-origin: margin;
     subcontrol-position: right bottom; }
   QToolButton::menu-arrow {
-    image: url(qss:images_dark-light/more_arrow_light.svg);
+    image: url(qss:images_dark-light/light_more_arrow.svg);
     width: 1.5ex;
     height: 1.5ex;
     subcontrol-origin: content;
@@ -547,6 +540,9 @@ QToolButton {
     /* Exclude a shift for better image */
     subcontrol-origin: padding;
     /* Shift it a bit */ }
+
+QToolBar > QToolButton#qt_toolbutton_menubutton {
+  padding-right: 2px; }
 
 QToolTip {
   padding: 4px;
@@ -568,10 +564,6 @@ QToolBar > Gui--WorkbenchComboBox QAbstractItemView {
 
 QWidget#wbList * {
   background-color: transparent; }
-
-QToolBar > QToolButton#qt_toolbutton_menubutton {
-  padding-right: 0px;
-  /* add more width to buttons with menu */ }
 
 /*==================================================================================================
 Tasks panel (custom FreeCAD class)

--- a/OpenDark/images_dark-light/light_more_arrow.svg
+++ b/OpenDark/images_dark-light/light_more_arrow.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="10"
+   height="6"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="light_down_arrow.svg"
+   viewBox="0 0 10 6"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#000000"
+     bordercolor="#c0c0c0"
+     borderopacity="1"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="37.597544"
+     inkscape:cx="9.601691"
+     inkscape:cy="6.4365906"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:object-nodes="true"
+     guidecolor="#0092ff"
+     guideopacity="0.49803922"
+     guidehicolor="#ff5200"
+     guidehiopacity="0.49803922"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-global="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1363"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     borderlayer="true"
+     units="px"
+     inkscape:showpageshadow="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2242"
+       originx="-5.8789061e-05"
+       originy="6.4096091e-06"
+       enabled="true"
+       spacingx="0.49999999"
+       spacingy="0.49999999"
+       empspacing="2"
+       color="#c63fff"
+       opacity="0.0627451"
+       units="px"
+       visible="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Pablo Gil</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>SVG</rdf:li>
+            <rdf:li>template</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="opacity: 0.4"
+     transform="translate(-1074.0664,-350.59799)">
+    <path
+       style="fill:#f1f3f5;fill-rule:evenodd;stroke:#f1f3f5;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-dashoffset:3.3;paint-order:markers fill stroke"
+       d="m 1075.5663,351.098 h 6 l -3,4 z"
+       id="path1"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/OpenDark/sass/FreeCAD_Dark.scss
+++ b/OpenDark/sass/FreeCAD_Dark.scss
@@ -570,9 +570,25 @@ QTextEdit {
 
 QToolBar {
     background-color: $main-bg;
-    margin-top: 6px;
-    padding: 0px;
+    padding: 2px;
     border-bottom: 1px solid $softborder;
+
+    * {
+        margin: 0;
+        padding: 0;
+    }
+
+    QTabBar {
+        &::tab { 
+            margin-top: -1px;
+            padding-top: 6px;
+        }
+    }
+
+    QPushButton {
+        padding: 3px;
+    }
+
     &::separator {
         background-color: $hardborder;
         &:vertical {
@@ -593,19 +609,7 @@ QToolBarExtension {
     qproperty-icon: url(qss:images_dark-light/light_expand.svg);
 }
 
-QToolButton[popupMode="0"] {
-    /* Only for InstantPopup */
-    padding-right: -20px;
-    margin-right: -20px;
-}
-
-  QToolButton[popupMode="1"] {
-    /* Only for InstantPopup */
-    padding-right: -20px;
-    margin-right: -20px;  
-}
-
-  QToolButton[popupMode="2"] {
+QToolButton[popupMode="0"], QToolButton[popupMode="1"], QToolButton[popupMode="2"] {
     /* Only for InstantPopup */
     padding-right: -20px;
     margin-right: -20px;
@@ -613,24 +617,31 @@ QToolButton[popupMode="0"] {
 
 QToolButton {
     margin: 0px 3px 0px 3px;
-    padding: 0px 0px 0px 0px;
+    padding: 2px;
+    
     @include noborder;
+    border-radius: 4px;
+    
     &:hover {
         margin: 0px 3px 0px 3px;
-        border: 1px solid $accent-border;
+        background: $control-bg;
     }
+    
     &:focus {
         margin: 0px 3px 0px 3px;
         border: 1px solid $accent-border;
     }
+    
     &:pressed {
         margin: 0px 3px 0px 3px;
         border: 1px solid $accent-border;
         background-color: $accent-bg;
     }
+    
     &:checked {
         background-color: $accent-bg;
     }
+
     &::menu-button {
         border-bottom: 0px solid #ffffff;
         border-radius: 2px;
@@ -642,19 +653,24 @@ QToolButton {
         subcontrol-origin: margin;
         subcontrol-position: right bottom;
     }
+
     &::menu-arrow {
-        image: url(qss:images_dark-light/more_arrow_light.svg);
         width: 1.5ex;
         height: 1.5ex;
         subcontrol-origin: content;
         subcontrol-position: right bottom;
         background: transparent;
     }
+
     &::menu-indicator {
         /* Exclude a shift for better image */
         subcontrol-origin: padding;
         /* Shift it a bit */
     }
+}
+
+QToolBar > QToolButton#qt_toolbutton_menubutton {
+    padding-right: 2px;
 }
 
 QToolTip {
@@ -687,10 +703,6 @@ QWidget#wbList * {
 
 QWidget#wbList QPushButton {
     @extend QPushButton;
-}
-
-QToolBar > QToolButton#qt_toolbutton_menubutton {
-    padding-right: 0px; /* add more width to buttons with menu */
 }
 
 /*==================================================================================================


### PR DESCRIPTION
This adds a little bit of breathing room for icons in toolbars and normalizes the look of toolbar buttons with other buttons. I also changed the arrow for dropdown to be ~~a little bit less contrasting, it was taken from https://tabler.io/icons~~ consistent with other dropdowns.

Before:
![image](https://github.com/obelisk79/OpenDark/assets/747404/c6041510-3ad4-4cb1-b997-4f5c84733902)

After:
![image](https://github.com/obelisk79/OpenDark/assets/747404/ef098047-e12a-4da6-a105-c9cc2ad50484)
